### PR TITLE
Fix Early Return Bug in `load_docs` Method

### DIFF
--- a/evaluation/data.py
+++ b/evaluation/data.py
@@ -62,9 +62,8 @@ class DataLoader:
         ```
         """
         if docs is not None:
-            return self.docs, None
-
-        if self.dataset == "trump":
+            self.docs, self.timestamps = docs, None
+        elif self.dataset == "trump":
             self.docs, self.timestamps = self._trump()
         elif self.dataset == "trump_dtm":
             self.docs, self.timestamps = self._trump_dtm()


### PR DESCRIPTION
### Bug Details
- **Early return when `docs` is not None**: The original code returned `self.docs, None` directly when `docs` was not `None`, which led to `self.docs` not being updated with the new `docs` parameter.
- **Save functionality not reached**: Due to the early return, the `save` flag's condition was never evaluated, and the `_save` method was not called when expected.

### Resolution
- The `docs` parameter is now correctly assigned to `self.docs`, and `self.timestamps` is set to `None` when custom documents are provided. This ensures that `self.docs` is always up to date.
- The early return has been removed to guarantee that the save condition is evaluated and the `_save` method is executed when `save` is `True`.